### PR TITLE
Add a link to fluentd.org in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Zeromq plugin for Fluentd
+Zeromq plugin for [Fluentd](http://fluentd.org)
 =============
 fluent-plugin-zmq provides an adaptor between fluentd and zeromq.
 


### PR DESCRIPTION
I am adding a link to Fluentd.org in your README.md file to put Fluentd in context for newcomers.
