### PR TITLE
Use cztop instead of rbzmq

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,4 @@ source :rubygems
 gemspec
 
 # fixme : make submodule
-gem "msgpack", "~>0.4.4"
-gem "zmq", "~>2.1.4"
 gem "fluentd" if RUBY_VERSION >= "1.9.2"

--- a/README.md
+++ b/README.md
@@ -16,28 +16,27 @@ Run a sample code.
 
 ~~~~~
     #!/usr/bin/env ruby
-    require 'zmq'
+    require 'cztop'
     require 'msgpack'
-    
-    z = ZMQ::Context.new
-    s = z.socket(ZMQ::DOWNSTREAM)
-    s.connect("tcp://127.0.0.1:4444")
+
+    s = CZTop::Socket::PUSH.new("tcp://127.0.0.1:4010")
     tag = "debug.test"
     # echo '{"json":"message"}' | fluent-cat debug.test
     array = ["key" => "value"]
-    
+
     def write_impl(s, tag, array)
+      msg = ''
       begin
-        s.send([tag, Time.now.to_s, array].to_msgpack)
+        s << [tag, Time.now.to_i, array].to_msgpack
       rescue
         $stderr.puts "write failed: #{$!}"
-        s.close
+      ensure
         return false
       end
-    
+
       return true
     end
-    
+
     write_impl(s, tag, array)
 ~~~~~
 
@@ -48,4 +47,3 @@ Happy logging with zeromq and fluetnd! :)
 - ZeroMQ output
 - ZeroMQ forwarding
 - JSON support
-

--- a/fluent-plugin-zmq.gemspec
+++ b/fluent-plugin-zmq.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_dependency "fluentd", [">= 0.10.58", "< 2"]
-  # specify any dependencies here; for example:
-  # s.add_development_dependency "rspec"
-  # s.add_runtime_dependency "rest-client"
+  s.add_dependency "cztop"
+  s.add_development_dependency "rake", ">= 0.9.2"
+  s.add_development_dependency "test-unit", ">= 3.0.8"
 end

--- a/fluent-plugin-zmq.gemspec
+++ b/fluent-plugin-zmq.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_dependency "fluentd", [">= 0.10.58", "< 2"]
+  s.add_dependency "fluentd", [">= 0.12.17", "< 2"]
   s.add_dependency "cztop"
   s.add_development_dependency "rake", ">= 0.9.2"
   s.add_development_dependency "test-unit", ">= 3.0.8"

--- a/lib/fluent/plugin/in_zmq.rb
+++ b/lib/fluent/plugin/in_zmq.rb
@@ -37,7 +37,7 @@ class ZMQInput < Input
 
   def configure(conf)
     super
-    @unpacker = Fluent::MessagePackFactory.engine_factory.unpacker
+    @unpacker = Fluent::Engine.msgpack_factory.unpacker
   end
 
   def start


### PR DESCRIPTION
Because rbzmq has been unmaintained since 4 years.
Let's migrate to use cztop instead of rbzmq.

cztop also provides fat gem for Windows.

Also this PR contains EventTime ext type fixes for v0.14 which can achieve with `Fluent::Engine.msgpack_factory.unpacker`'s `#feed` and `#read` instances.

Could you take a look?

Thanks in advance,